### PR TITLE
Implement pull request close events

### DIFF
--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -236,7 +236,6 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		}
 		return hook, repo, nil
 	case *scm.PullRequestHook:
-
 		// TODO(bradrydzewski) cleanup the pr close hook code.
 		if v.Action == scm.ActionClose {
 			return &core.Hook{
@@ -253,9 +252,13 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 				}, nil
 		}
 
-		if v.Action != scm.ActionOpen && v.Action != scm.ActionSync {
+		switch v.Action {
+		case scm.ActionOpen, scm.ActionClose, scm.ActionSync:
+			// Valid, continue
+		default:
 			return nil, nil, nil
 		}
+
 		// Pull Requests are not supported for Bitbucket due
 		// to lack of refs (e.g. refs/pull-requests/42/from).
 		// Please contact Bitbucket Support if you would like to
@@ -264,6 +267,7 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		if p.client.Driver == scm.DriverBitbucket {
 			return nil, nil, nil
 		}
+
 		hook = &core.Hook{
 			Trigger:      core.TriggerHook, // core.TriggerHook,
 			Event:        core.EventPullRequest,

--- a/trigger/skip.go
+++ b/trigger/skip.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/drone/drone-yaml/yaml"
 	"github.com/drone/drone/core"
+	"github.com/drone/go-scm/scm"
 )
 
 func skipBranch(document *yaml.Pipeline, branch string) bool {
@@ -99,14 +100,13 @@ func skipMessageEval(str string) bool {
 // events should be propagated but the "close" event should not.
 func skipPullRequestEval(document *yaml.Pipeline, action string) bool {
 	// If the trigger event is explicit the check is handled by `skipEvent`.
-	if len(document.Trigger.Action.Include) > 0 {
+	if len(document.Trigger.Action.Include) > 0 || len(document.Trigger.Action.Exclude) > 0 {
 		return false
 	}
 
 	// The default behaviour of the pull request
 	switch action {
-	case core.ActionSync:
-	case core.ActionOpen:
+	case scm.ActionOpen.String(), scm.ActionSync.String():
 		return false
 	}
 

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -28,8 +28,6 @@ import (
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/trigger/dag"
 
-	"github.com/drone/go-scm/scm"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -296,24 +294,9 @@ func (t *triggerer) Trigger(ctx context.Context, repo *core.Repository, base *co
 		// TODO add target
 		// TODO add ref
 
-		// Insert Defaults
 		name := pipeline.Name
 		if name == "" {
 			name = "default"
-		}
-
-		// With the introduction of the "close" event in drone the default behaviour changes from "opt in to opens
-		// only" to "opt in to all".
-		//
-		// So as to preserve BC, this polyfills the previous design of "open" and "sync" events being included, but
-		// "exclude" events not. This allows users to "opt in" to the exclude behaviour.
-		if pipeline.Trigger.Event.Match(core.EventPullRequest) &&
-			len(pipeline.Trigger.Action.Include) == 0 {
-			pipeline.Trigger.Action.Include = append(
-				pipeline.Trigger.Action.Include,
-				scm.ActionOpen.String(),
-				scm.ActionSync.String(),
-			)
 		}
 
 		node := dag.Add(pipeline.Name, pipeline.DependsOn...)


### PR DESCRIPTION
There is currently a feature request associated with being able to run
some sort of pipeline at the termination of some git event; specifically
in this case a "closure" of a pull request.

This allows the consumers of drone to use drone to spin up ephemeral
environments for the purpose of testing, and then later have them torn
down automatically by Drone once the pull request has been closed.

This commit implements such a solution after reading the guidance on:

  #2884

The commits describe the design path in further detail.