### PR TITLE
remove parent promote build params

### DIFF
--- a/handler/api/repos/builds/promote.go
+++ b/handler/api/repos/builds/promote.go
@@ -76,10 +76,6 @@ func HandlePromote(
 			Params:       map[string]string{},
 		}
 
-		for k, v := range prev.Params {
-			hook.Params[k] = v
-		}
-
 		for key, value := range r.URL.Query() {
 			if key == "access_token" {
 				continue


### PR DESCRIPTION
When I try to build from historical promote, I always inherit parameters.
This makes the build a lot of mistakes.
A promote may have many parameters, and only a part of them will be used most of the time.I think reentering is more comfortable than inheriting.