### PR TITLE
Add tag filter when call build list endpoint

### DIFF
--- a/handler/api/repos/builds/list.go
+++ b/handler/api/repos/builds/list.go
@@ -37,6 +37,7 @@ func HandleList(
 			namespace = chi.URLParam(r, "owner")
 			name      = chi.URLParam(r, "name")
 			branch    = r.FormValue("branch")
+			tag       = r.FormValue("tag")
 			page      = r.FormValue("page")
 			perPage   = r.FormValue("per_page")
 		)
@@ -65,6 +66,9 @@ func HandleList(
 		var results []*core.Build
 		if branch != "" {
 			ref := fmt.Sprintf("refs/heads/%s", branch)
+			results, err = builds.ListRef(r.Context(), repo.ID, ref, limit, offset)
+		} else if tag != "" {
+			ref := fmt.Sprintf("refs/tags/%s", tag)
 			results, err = builds.ListRef(r.Context(), repo.ID, ref, limit, offset)
 		} else {
 			results, err = builds.List(r.Context(), repo.ID, limit, offset)


### PR DESCRIPTION
Filtering by tag will be very useful for us when we calls builds list endpoint.

Basically I assume `branch` and `tag` filters can't be defined together and I think those kind of parameters can be handled better but it requires a major refactor, the sqlx part too.

@bradrydzewski @eoinmcafee00 if this PR looks good could you merge ASAP? Thank you :pray:  