### PR TITLE
Fix wrong address being transferred to local http server (non https/SSL) Port was forwarded instead

### DIFF
--- a/cmd/drone-server/inject_server.go
+++ b/cmd/drone-server/inject_server.go
@@ -116,7 +116,7 @@ func provideRPC2(m manager.BuildManager, config config.Config) rpcHandlerV2 {
 func provideServer(handler *chi.Mux, config config.Config) *server.Server {
 	return &server.Server{
 		Acme:    config.Server.Acme,
-		Addr:    config.Server.Port,
+		Addr:    config.Server.Addr,
 		Cert:    config.Server.Cert,
 		Key:     config.Server.Key,
 		Host:    config.Server.Host,

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func (s Server) ListenAndServe(ctx context.Context) error {
 func (s Server) listenAndServe(ctx context.Context) error {
 	var g errgroup.Group
 	s1 := &http.Server{
-		Addr:    s.Addr,
+		Addr:    s.Host,
 		Handler: s.Handler,
 	}
 	g.Go(func() error {


### PR DESCRIPTION
When using a localhost installation (see configuration below), the http server is binded on :port which is wrong on windows distribution for instance and do not respect the HOST directive.

## Intent
Fix a bug when using a localhost installation

Configuration:
DRONE_SERVER_PROTO=http
DRONE_SERVER_HOST=127.0.0.1:3000
DRONE_SERVER_PORT=3000

## Why this bug was first introduced

I assume that this bug was introduced due to a kubernetes bug when the instance could not be realisatically reflected with the simple HOST, however having two field like SERVER_HOST and SERVER_PORT are confusing when SERVER_HOST accept DNS name and ip_address[:port], this case should be clarified as currently only DRONE_SERVER_PORT is used when using local binding.

