### PR TITLE
Added OAuth2 token refresher for Gitlab

### DIFF
--- a/cmd/drone-server/inject_client.go
+++ b/cmd/drone-server/inject_client.go
@@ -180,7 +180,13 @@ func provideGitlabClient(config config.Config) *scm.Client {
 	}
 	client.Client = &http.Client{
 		Transport: &oauth2.Transport{
-			Source: oauth2.ContextTokenSource(),
+			Scheme: oauth2.SchemeBearer,
+			Source: &oauth2.Refresher{
+				ClientID:     config.GitLab.ClientID,
+				ClientSecret: config.GitLab.ClientSecret,
+				Endpoint:     strings.TrimSuffix(config.GitLab.Server, "/") + "/oauth/token",
+				Source:       oauth2.ContextTokenSource(),
+			},
 			Base:   defaultTransport(config.GitLab.SkipVerify),
 		},
 	}

--- a/cmd/drone-server/inject_login.go
+++ b/cmd/drone-server/inject_login.go
@@ -197,6 +197,14 @@ func provideRefresher(config config.Config) *oauth2.Refresher {
 			Source:       oauth2.ContextTokenSource(),
 			Client:       defaultClient(config.Gitea.SkipVerify),
 		}
+	case config.GitLab.ClientID != "":
+		return &oauth2.Refresher{
+			ClientID:     config.GitLab.ClientID,
+			ClientSecret: config.GitLab.ClientSecret,
+			Endpoint:     strings.TrimSuffix(config.GitLab.Server, "/") + "/oauth/token",
+			Source:       oauth2.ContextTokenSource(),
+			Client:       defaultClient(config.GitLab.SkipVerify),
+		}
 	case config.Gitee.ClientID != "":
 		return &oauth2.Refresher{
 			ClientID:     config.Gitee.ClientID,


### PR DESCRIPTION
Fixes the bug (reported [here](https://community.harness.io/t/drone-doesnt-implment-gitlab-oauth2-token-refresh-and-causes-404-and-code-change-webhook-fails)) introduced by recent changes to Gitlab token expiration. Blatant copy-paste of Gitea implementation (please feel free to improve if problematic), but tested and working on our local Drone deployment.