### PR TITLE
(bug) add unit test for comments in template file

### DIFF
--- a/plugin/converter/template_test.go
+++ b/plugin/converter/template_test.go
@@ -388,6 +388,7 @@ func TestTemplatePluginConvertYaml(t *testing.T) {
 		t.Errorf("Want %q got %q", want, got)
 	}
 }
+
 // tests to check error is thrown if user has already loaded a template file of invalid extension
 // and refers to it in the drone.yml file
 func TestTemplatePluginConvertInvalidTemplateExtension(t *testing.T) {
@@ -434,5 +435,67 @@ func TestTemplatePluginConvertInvalidTemplateExtension(t *testing.T) {
 	config, err := plugin.Convert(noContext, req)
 	if config != nil {
 		t.Errorf("template extension invalid. must be yaml, starlark or jsonnet")
+	}
+}
+
+func TestTemplatePluginConvertYamlWithComment(t *testing.T) {
+	templateArgs, err := ioutil.ReadFile("testdata/yaml.template.comment.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	req := &core.ConvertArgs{
+		Build: &core.Build{
+			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
+		},
+		Repo: &core.Repository{
+			Slug:      "octocat/hello-world",
+			Config:    ".drone.yml",
+			Namespace: "octocat",
+		},
+		Config: &core.Config{
+			Data: string(templateArgs),
+		},
+	}
+
+	beforeInput, err := ioutil.ReadFile("testdata/yaml.input.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	after, err := ioutil.ReadFile("testdata/yaml.input.golden")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	template := &core.Template{
+		Name:      "plugin.yaml",
+		Data:      string(beforeInput),
+		Namespace: "octocat",
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	templates := mock.NewMockTemplateStore(controller)
+	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
+
+	plugin := Template(templates, 0)
+	config, err := plugin.Convert(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if config == nil {
+		t.Error("Want non-nil configuration")
+		return
+	}
+
+	if want, got := config.Data, string(after); want != got {
+		t.Errorf("Want %q got %q", want, got)
 	}
 }

--- a/plugin/converter/testdata/yaml.template.comment.yml
+++ b/plugin/converter/testdata/yaml.template.comment.yml
@@ -1,0 +1,8 @@
+---
+# this is a comment
+kind: template
+load: plugin.yaml
+data:
+  stepName: my_step
+  image: my_image
+  commands: my_command


### PR DESCRIPTION
added a unit test to confirm this was no longer an issue:
https://community.harness.io/t/comments-break-drone-templates/11704
