### PR TITLE
Template converter, don't skip .yaml extension.

### DIFF
--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"path/filepath"
 	"regexp"
-	"strings"
 	templating "text/template"
 
 	"github.com/drone/drone/core"
@@ -56,7 +55,9 @@ type templatePlugin struct {
 
 func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Config, error) {
 	// check type is yaml
-	if strings.HasSuffix(req.Repo.Config, ".yml") == false {
+	configExt := filepath.Ext(req.Repo.Config)
+
+	if configExt != ".yml" && configExt != ".yaml" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
I started running into issues when trying out the templating feature of Drone. Most of our dronefiles are using the `.yaml` extensions rather than the shorter `.yml` extension. The template converter ignores for any Dronefile that isn't using the shorter `.yml` extension.

This pull-request will allow the template converter to accept `.yaml` extensions as-well. 

I believe this pull-request would also fix the issue described here: https://github.com/harness/drone/issues/3237