### PR TITLE
fix(repo): use `src.Clone` to convert name and slug

### DIFF
--- a/service/repo/util.go
+++ b/service/repo/util.go
@@ -17,6 +17,7 @@ package repo
 import (
 	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
+	"strings"
 )
 
 // convertRepository is a helper function that converts a
@@ -26,8 +27,8 @@ func convertRepository(src *scm.Repository, visibility string, trusted bool) *co
 	return &core.Repository{
 		UID:        src.ID,
 		Namespace:  src.Namespace,
-		Name:       src.Name,
-		Slug:       scm.Join(src.Namespace, src.Name),
+		Name:       convertName(src),
+		Slug:       convertSlug(src),
 		HTTPURL:    src.Clone,
 		SSHURL:     src.CloneSSH,
 		Link:       src.Link,
@@ -56,4 +57,20 @@ func convertVisibility(src *scm.Repository, visibility string) string {
 	default:
 		return core.VisibilityPublic
 	}
+}
+
+func convertName(src *scm.Repository) string {
+	if src.Clone != "" {
+		s := strings.SplitN(src.Clone, "/", 5)
+		name := strings.SplitN(s[4], ".", 2)[0]
+		if src.Name != name {
+			return name
+		}
+	}
+	return src.Name
+}
+
+func convertSlug(src *scm.Repository) string {
+	name := convertName(src)
+	return scm.Join(src.Namespace, name)
 }

--- a/service/repo/util_test.go
+++ b/service/repo/util_test.go
@@ -96,3 +96,39 @@ func TestDefinedVisibility(t *testing.T) {
 		t.Errorf(diff)
 	}
 }
+
+func TestConvertName(t *testing.T) {
+	from := &scm.Repository{
+		ID:        "42",
+		Namespace: "octocat",
+		Name:      "hello-world",
+		Branch:    "master",
+		Private:   false,
+		Clone:     "https://github.com/octocat/hello-world.git",
+		CloneSSH:  "git@github.com:octocat/hello-world.git",
+		Link:      "https://github.com/octocat/hello-world",
+	}
+	want := "hello-world"
+	got := convertName(from)
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf(diff)
+	}
+}
+
+func TestConvertSlug(t *testing.T) {
+	from := &scm.Repository{
+		ID:        "42",
+		Namespace: "octocat",
+		Name:      "hello world",
+		Branch:    "master",
+		Private:   false,
+		Clone:     "https://github.com/octocat/hello-world.git",
+		CloneSSH:  "git@github.com:octocat/hello-world.git",
+		Link:      "https://github.com/octocat/hello-world",
+	}
+	want := "octocat/hello-world"
+	got := convertSlug(from)
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf(diff)
+	}
+}


### PR DESCRIPTION
use `src.Clone` to covert name and slug

fix gitee bug: https://github.com/drone/go-scm/issues/217