### PR TITLE
Enhance status check label for promotions

### DIFF
--- a/service/status/status.go
+++ b/service/status/status.go
@@ -84,7 +84,7 @@ func (s *service) Send(ctx context.Context, user *core.User, req *core.StatusInp
 	_, _, err = s.client.Repositories.CreateStatus(ctx, req.Repo.Slug, req.Build.After, &scm.StatusInput{
 		Title:  fmt.Sprintf("Build #%d", req.Build.Number),
 		Desc:   createDesc(req.Build.Status),
-		Label:  createLabel(s.name, req.Build.Event),
+		Label:  createLabel(s.name, req.Build.Event, req.Build.Deploy),
 		State:  convertStatus(req.Build.Status),
 		Target: fmt.Sprintf("%s/%s/%d", s.base, req.Repo.Slug, req.Build.Number),
 	})

--- a/service/status/util.go
+++ b/service/status/util.go
@@ -21,7 +21,7 @@ import (
 	"github.com/drone/go-scm/scm"
 )
 
-func createLabel(name, event string) string {
+func createLabel(name, event, deployTo string) string {
 	if name == "" {
 		name = "continuous-integration/drone"
 	}
@@ -32,6 +32,8 @@ func createLabel(name, event string) string {
 		return fmt.Sprintf("%s/pr", name)
 	case core.EventTag:
 		return fmt.Sprintf("%s/tag", name)
+	case core.EventPromote:
+		return fmt.Sprintf("%s/promote/%s", name, deployTo)
 	default:
 		return name
 	}

--- a/service/status/util.go
+++ b/service/status/util.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
+	"github.com/gosimple/slug"
 )
 
 func createLabel(name, event, deployTo string) string {
@@ -33,7 +34,7 @@ func createLabel(name, event, deployTo string) string {
 	case core.EventTag:
 		return fmt.Sprintf("%s/tag", name)
 	case core.EventPromote:
-		return fmt.Sprintf("%s/promote/%s", name, deployTo)
+		return fmt.Sprintf("%s/promote/%s", name, slug.Make(deployTo))
 	default:
 		return name
 	}

--- a/service/status/util_test.go
+++ b/service/status/util_test.go
@@ -36,6 +36,11 @@ func TestCreateLabel(t *testing.T) {
 			label:    "continuous-integration/drone/promote/production",
 		},
 		{
+			event:    core.EventPromote,
+			deployTo: "$production%",
+			label:    "continuous-integration/drone/promote/production",
+		},
+		{
 			event: "unknown",
 			label: "continuous-integration/drone",
 		},

--- a/service/status/util_test.go
+++ b/service/status/util_test.go
@@ -13,9 +13,10 @@ import (
 
 func TestCreateLabel(t *testing.T) {
 	tests := []struct {
-		name  string
-		event string
-		label string
+		name     string
+		event    string
+		label    string
+		deployTo string
 	}{
 		{
 			event: core.EventPullRequest,
@@ -30,6 +31,11 @@ func TestCreateLabel(t *testing.T) {
 			label: "continuous-integration/drone/tag",
 		},
 		{
+			event:    core.EventPromote,
+			deployTo: "production",
+			label:    "continuous-integration/drone/promote/production",
+		},
+		{
 			event: "unknown",
 			label: "continuous-integration/drone",
 		},
@@ -40,7 +46,7 @@ func TestCreateLabel(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if got, want := createLabel(test.name, test.event), test.label; got != want {
+		if got, want := createLabel(test.name, test.event, test.deployTo), test.label; got != want {
 			t.Errorf("Want label %q, got %q", want, got)
 		}
 	}


### PR DESCRIPTION
This PR introduces a change for labels applied to status checks related to promotions, actually a generic one is used.