### PR TITLE
Add endpoint for allowing admins to force rotate a user's token

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -340,6 +340,7 @@ func (s Server) Handler() http.Handler {
 		r.Post("/", users.HandleCreate(s.Users, s.Userz, s.Webhook))
 		r.Get("/{user}", users.HandleFind(s.Users))
 		r.Patch("/{user}", users.HandleUpdate(s.Users, s.Transferer))
+		r.Post("/{user}/token/rotate", users.HandleTokenRotation(s.Users))
 		r.Delete("/{user}", users.HandleDelete(s.Users, s.Transferer, s.Webhook))
 		r.Get("/{user}/repos", users.HandleRepoList(s.Users, s.Repos))
 	})

--- a/handler/api/users/token.go
+++ b/handler/api/users/token.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package users
+
+import (
+	"net/http"
+
+	"github.com/dchest/uniuri"
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+	"github.com/go-chi/chi"
+)
+
+type userWithMessage struct {
+	*core.User
+	Message string `json:"message"`
+}
+
+// HandleToken returns an http.HandlerFunc that writes json-encoded
+// account information to the http response body with the user token.
+func HandleTokenRotation(users core.UserStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		login := chi.URLParam(r, "user")
+		user, err := users.FindLogin(r.Context(), login)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).WithError(err).
+				Debugln("api: cannot find user")
+			return
+		}
+		user.Hash = uniuri.NewLen(32)
+		if err := users.Update(r.Context(), user); err != nil {
+			render.InternalError(w, err)
+			return
+		}
+		render.JSON(w, &userWithMessage{user, "Token rotated successfully."}, 200)
+	}
+}

--- a/handler/api/users/token_test.go
+++ b/handler/api/users/token_test.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package users
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/mock"
+	"github.com/go-chi/chi"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// The purpose of this test is to make sure admins can rotate someone
+// else's token.
+func TestTokenRotate(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	startingHash := "MjAxOC0wOC0xMVQxNTo1ODowN1o"
+	mockUser := &core.User{
+		ID:    1,
+		Login: "octocat",
+		Hash:  startingHash,
+	}
+
+	c := new(chi.Context)
+	c.URLParams.Add("user", "octocat")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/", nil)
+	r = r.WithContext(
+		context.WithValue(context.Background(), chi.RouteCtxKey, c),
+	)
+
+	users := mock.NewMockUserStore(controller)
+	users.EXPECT().FindLogin(gomock.Any(), mockUser.Login).Return(mockUser, nil)
+	users.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+	HandleTokenRotation(users)(w, r)
+	if got, want := w.Code, 200; want != got {
+		t.Errorf("Want response code %d, got %d", want, got)
+	}
+
+	got, want := &userWithMessage{}, mockUser
+	json.NewDecoder(w.Body).Decode(got)
+
+	ignore := cmpopts.IgnoreFields(core.User{}, "Hash")
+	if diff := cmp.Diff(got.User, want, ignore); len(diff) != 0 {
+		t.Errorf(diff)
+	}
+	if got.Message == "" {
+		t.Errorf("Expect Message returned")
+	}
+	if got, want := mockUser.Hash, startingHash; got == want {
+		t.Errorf("Expect user hash updated")
+	}
+}
+
+// // the purpose of this unit test is to verify that an error
+// // updating the database will result in an internal server
+// // error returned to the client.
+// func TestToken_UpdateError(t *testing.T) {
+// 	controller := gomock.NewController(t)
+// 	defer controller.Finish()
+
+// 	mockUser := &core.User{
+// 		ID:    1,
+// 		Login: "octocat",
+// 	}
+
+// 	w := httptest.NewRecorder()
+// 	r := httptest.NewRequest("POST", "/?rotate=true", nil)
+// 	r = r.WithContext(
+// 		request.WithUser(r.Context(), mockUser),
+// 	)
+
+// 	users := mock.NewMockUserStore(controller)
+// 	users.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.ErrNotFound)
+
+// 	HandleToken(users)(w, r)
+// 	if got, want := w.Code, 500; want != got {
+// 		t.Errorf("Want response code %d, got %d", want, got)
+// 	}
+
+// 	got, want := new(errors.Error), errors.ErrNotFound
+// 	json.NewDecoder(w.Body).Decode(got)
+// 	if diff := cmp.Diff(got, want); len(diff) != 0 {
+// 		t.Errorf(diff)
+// 	}
+// }


### PR DESCRIPTION
**Reason**: Better security management as admins can force rotate a token if someone commits their token in plaintext somewhere.
**To Test**
0. Requires 2 user accounts for testing. 1 admin 1 nonadmin
1. `curl -X POST -H"Authorization: Bearer <admintoken>" <droneserver>/api/users/<nonadmin-username>/token/rotate
2. Go to <nonadmin-username>'s user page while logged in as them
3. Verify token rotated
4. `curl -X POST -H"Authorization: Bearer <nonadmintoken>" <droneserver>/api/users/<admin-username>/token/rotate 
5. Receive Error
6. Go to <admin-username>'s user page while logged in as them
7. Verify token did not rotate

### From Checklist: 
- [x] Commit is a single logical unit of work, only use multiple commits if doing different tasks
- [x] Commit does not include commented out code or unneeded files
- [x] Rebase of main branch

### The Content

- [x] Must include testing for bug or feature
- [ ] Must include appropriate documentation changes if it is introducing a new feature or changing existing functionality
- [x] Must pass existing test suites

### The Commit Message

- [x] Short meaningful description (ex: remove deprecated steps)
- [x] Uses the imperative, present tense: "change", not "changed" or "changes"
- [x] Includes motivation for the change, and contrasts its implementation with the previous behavior

### The Pull Request

- [x] What is the reason for this change
- [x] Example usage of the failure for a bug, or configuration and expected output for a feature
- [x] Steps to test the change
