### PR TITLE
Make Starlark file size limit configurable

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -148,6 +148,7 @@ type (
 	Starlark struct {
 		Enabled   bool   `envconfig:"DRONE_STARLARK_ENABLED"`
 		StepLimit uint64 `envconfig:"DRONE_STARLARK_STEP_LIMIT"`
+		SizeLimit uint64 `envconfig:"DRONE_STARLARK_SIZE_LIMIT" default:"0"`
 	}
 
 	// License provides license configuration

--- a/cmd/drone-server/inject_plugin.go
+++ b/cmd/drone-server/inject_plugin.go
@@ -83,6 +83,7 @@ func provideConvertPlugin(client *scm.Client, fileService core.FileService, conf
 		converter.Starlark(
 			conf.Starlark.Enabled,
 			conf.Starlark.StepLimit,
+			conf.Starlark.SizeLimit,
 		),
 		converter.Jsonnet(
 			conf.Jsonnet.Enabled,
@@ -92,6 +93,7 @@ func provideConvertPlugin(client *scm.Client, fileService core.FileService, conf
 		converter.Template(
 			templateStore,
 			conf.Starlark.StepLimit,
+			conf.Starlark.SizeLimit,
 		),
 		converter.Memoize(
 			converter.Remote(

--- a/plugin/converter/starlark.go
+++ b/plugin/converter/starlark.go
@@ -26,16 +26,18 @@ import (
 
 // Starlark returns a conversion service that converts the
 // starlark file to a yaml file.
-func Starlark(enabled bool, stepLimit uint64) core.ConvertService {
+func Starlark(enabled bool, stepLimit uint64, sizeLimit uint64) core.ConvertService {
 	return &starlarkPlugin{
 		enabled: enabled,
 		stepLimit: stepLimit,
+		sizeLimit: sizeLimit,
 	}
 }
 
 type starlarkPlugin struct {
 	enabled bool
 	stepLimit uint64
+	sizeLimit uint64
 }
 
 func (p *starlarkPlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Config, error) {
@@ -53,7 +55,7 @@ func (p *starlarkPlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 		return nil, nil
 	}
 
-	file, err := starlark.Parse(req, nil, nil, p.stepLimit)
+	file, err := starlark.Parse(req, nil, nil, p.stepLimit, p.sizeLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/converter/starlark/starlark_test.go
+++ b/plugin/converter/starlark/starlark_test.go
@@ -57,7 +57,7 @@ func TestParseStarlark(t *testing.T) {
 
 	req.Config.Data = string(before)
 
-	parsedFile, err := Parse(req, template, templateData, 0)
+	parsedFile, err := Parse(req, template, templateData, 0, 0)
 	if err != nil {
 		t.Error(err)
 		return
@@ -95,7 +95,7 @@ func TestParseStarlarkNotTemplateFile(t *testing.T) {
 	req.Repo.Config = "plugin.starlark.star"
 	req.Config.Data = string(before)
 
-	parsedFile, err := Parse(req, nil, nil, 0)
+	parsedFile, err := Parse(req, nil, nil, 0, 0)
 	if err != nil {
 		t.Error(err)
 		return

--- a/plugin/converter/starlark_oss.go
+++ b/plugin/converter/starlark_oss.go
@@ -18,6 +18,6 @@ package converter
 
 import "github.com/drone/drone/core"
 
-func Starlark(enabled bool, stepLimit uint64) core.ConvertService {
+func Starlark(enabled bool, stepLimit uint64, sizeLimit uint64) core.ConvertService {
 	return new(noop)
 }

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -41,16 +41,18 @@ var (
 	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")
 )
 
-func Template(templateStore core.TemplateStore, stepLimit uint64) core.ConvertService {
+func Template(templateStore core.TemplateStore, stepLimit uint64, sizeLimit uint64) core.ConvertService {
 	return &templatePlugin{
 		templateStore: templateStore,
 		stepLimit: stepLimit,
+		sizeLimit: sizeLimit,
 	}
 }
 
 type templatePlugin struct {
 	templateStore core.TemplateStore
 	stepLimit uint64
+	sizeLimit uint64
 }
 
 func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Config, error) {
@@ -84,7 +86,7 @@ func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 	case ".yml", ".yaml":
 		return parseYaml(req, template, templateArgs)
 	case ".star", ".starlark", ".script":
-		return parseStarlark(req, template, templateArgs, p.stepLimit)
+		return parseStarlark(req, template, templateArgs, p.stepLimit, p.sizeLimit)
 	case ".jsonnet":
 		return parseJsonnet(req, template, templateArgs)
 	default:
@@ -122,8 +124,8 @@ func parseJsonnet(req *core.ConvertArgs, template *core.Template, templateArgs c
 	}, nil
 }
 
-func parseStarlark(req *core.ConvertArgs, template *core.Template, templateArgs core.TemplateArgs, stepLimit uint64) (*core.Config, error) {
-	file, err := starlark.Parse(req, template, templateArgs.Data, stepLimit)
+func parseStarlark(req *core.ConvertArgs, template *core.Template, templateArgs core.TemplateArgs, stepLimit uint64, sizeLimit uint64) (*core.Config, error) {
+	file, err := starlark.Parse(req, template, templateArgs.Data, stepLimit, sizeLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/converter/template_oss.go
+++ b/plugin/converter/template_oss.go
@@ -22,7 +22,7 @@ import (
 	"github.com/drone/drone/core"
 )
 
-func Template(templateStore core.TemplateStore, stepLimit uint64) core.ConvertService {
+func Template(templateStore core.TemplateStore, stepLimit uint64, sizeLimit uint64) core.ConvertService {
 	return &templatePlugin{
 		templateStore: templateStore,
 	}

--- a/plugin/converter/template_test.go
+++ b/plugin/converter/template_test.go
@@ -73,7 +73,7 @@ func TestTemplatePluginConvertStarlark(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
 		t.Error(err)
@@ -92,7 +92,7 @@ func TestTemplatePluginConvertStarlark(t *testing.T) {
 
 func TestTemplatePluginConvertNotYamlFile(t *testing.T) {
 
-	plugin := Template(nil, 0)
+	plugin := Template(nil, 0, 0)
 	req := &core.ConvertArgs{
 		Build: &core.Build{
 			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
@@ -120,7 +120,7 @@ func TestTemplatePluginConvertDroneFileTypePipeline(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	plugin := Template(nil, 0)
+	plugin := Template(nil, 0, 0)
 	req := &core.ConvertArgs{
 		Build: &core.Build{
 			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
@@ -161,7 +161,7 @@ func TestTemplatePluginConvertDroneFileYamlExtensions(t *testing.T) {
 			templates := mock.NewMockTemplateStore(controller)
 			templates.EXPECT().FindName(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, dummyErr)
 
-			plugin := Template(templates, 0)
+			plugin := Template(templates, 0, 0)
 			req := &core.ConvertArgs{
 				Build: &core.Build{
 					After: "3d21ec53a331a6f037a91c368710b99387d012c1",
@@ -214,7 +214,7 @@ func TestTemplatePluginConvertTemplateNotFound(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(nil, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 
 	config, err := plugin.Convert(noContext, req)
 	if config != nil {
@@ -267,7 +267,7 @@ func TestTemplatePluginConvertJsonnet(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
 		t.Error(err)
@@ -346,7 +346,7 @@ func TestTemplateNestedValuesPluginConvertStarlark(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
 		t.Error(err)
@@ -424,7 +424,7 @@ func TestTemplatePluginConvertYaml(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
 		t.Error(err)
@@ -483,7 +483,7 @@ func TestTemplatePluginConvertInvalidTemplateExtension(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if config != nil {
 		t.Errorf("template extension invalid. must be yaml, starlark or jsonnet")
@@ -535,7 +535,7 @@ func TestTemplatePluginConvertYamlWithComment(t *testing.T) {
 	templates := mock.NewMockTemplateStore(controller)
 	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
 
-	plugin := Template(templates, 0)
+	plugin := Template(templates, 0, 0)
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This PR introduces a way to configure the Starlark generated YAML size limit as opposed to having a hard-coded value.
The default behavior does not change, but a user can set `DRONE_STARLARK_SIZE_LIMIT` env var on the drone server to allow for a larger file.
This would resolve an issue described [here](https://community.harness.io/t/starlark-maximum-file-size-exceeded-for-large-amount-of-pipelines/12623).

## Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

### The Basics

- Commit is a single logical unit of work, only use multiple commits if doing different tasks
- Commit does not include commented out code or unneeded files
- rebase of main branch

### The Content

- Must include testing for bug or feature
- Must include appropriate documentation changes if it is introducing a new feature or changing existing functionality
- Must pass existing test suites

### The Commit Message

- Short meaningful description (ex: remove deprecated steps)
- Uses the imperative, present tense: "change", not "changed" or "changes"
- Includes motivation for the change, and contrasts its implementation with the previous behavior

### The Pull Request

- What is the reason for this change
- Example usage of the failure for a bug, or configuration and expected output for a feature
- Steps to test the change
