### PR TITLE
support custom pipeline message

### DIFF
--- a/handler/api/repos/builds/create.go
+++ b/handler/api/repos/builds/create.go
@@ -40,6 +40,7 @@ func HandleCreate(
 			name      = chi.URLParam(r, "name")
 			sha       = r.FormValue("commit")
 			branch    = r.FormValue("branch")
+			message   = r.FormValue("message")
 			user, _   = request.UserFrom(ctx)
 		)
 
@@ -92,6 +93,9 @@ func HandleCreate(
 			AuthorAvatar: commit.Author.Avatar,
 			Sender:       user.Login,
 			Params:       map[string]string{},
+		}
+		if len(message) > 0 {
+			hook.Message = message
 		}
 
 		for key, value := range r.URL.Query() {


### PR DESCRIPTION
Support cutom pipeline customization to commit message information, 
which will help to view associated triggers and debug troubleshooting.

## Actual

I create custom build in another pipeline, but I can't see some useful information of these builds on the list.
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/28284116/206956100-7ad3badd-8b52-4f97-a0e4-e1de9c66c0c0.png">

## Expect

I can customize the `commit message` information when creating `custom build`, so that it can write the build number triggered by the associated pipeline.

e.g. 

```
# 19  Triggered by build number 15 of root/test
# 18  Triggered by build number 14 of root/test
# 17  Triggered by build number 13 of root/test
```