### PR TITLE
store/card: fix dropped error

### DIFF
--- a/store/card/card.go
+++ b/store/card/card.go
@@ -62,6 +62,9 @@ func (c cardStore) Create(ctx context.Context, step int64, r io.Reader) error {
 			Data: data,
 		}
 		params, err := toParams(in)
+		if err != nil {
+			return err
+		}
 		stmt, args, err := binder.BindNamed(stmtInsert, params)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes a dropped error in `store/card`.