### PR TITLE
Add config for the buffer

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -103,6 +103,7 @@ type (
 		Interval time.Duration `envconfig:"DRONE_CLEANUP_INTERVAL"         default:"24h"`
 		Running  time.Duration `envconfig:"DRONE_CLEANUP_DEADLINE_RUNNING" default:"24h"`
 		Pending  time.Duration `envconfig:"DRONE_CLEANUP_DEADLINE_PENDING" default:"24h"`
+		Buffer   time.Duration `envconfig:"DRONE_CLEANUP_BUFFER" default:"30m"`
 	}
 
 	// Cron provides the cron configuration.

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -181,6 +181,7 @@ func provideReaper(
 		canceler,
 		config.Cleanup.Running,
 		config.Cleanup.Pending,
+		config.Cleanup.Buffer,
 	)
 }
 
@@ -212,7 +213,7 @@ func provideDatadog(
 			EnableStash:     config.IsStash(),
 			EnableGogs:      config.IsGogs(),
 			EnableGitea:     config.IsGitea(),
-			EnableGitee:	 config.IsGitee(),
+			EnableGitee:     config.IsGitee(),
 			EnableAgents:    !config.Agent.Disabled,
 		},
 	)

--- a/service/canceler/reaper/reaper_test.go
+++ b/service/canceler/reaper/reaper_test.go
@@ -72,6 +72,7 @@ func TestReapPending(t *testing.T) {
 		canceler,
 		time.Hour*24,
 		time.Hour*24,
+		time.Minute*30,
 	)
 
 	r.reap(nocontext)
@@ -139,6 +140,7 @@ func TestReapRunning(t *testing.T) {
 		canceler,
 		time.Hour*24,
 		time.Hour*24,
+		time.Minute*30,
 	)
 
 	r.reap(nocontext)

--- a/service/canceler/reaper/util.go
+++ b/service/canceler/reaper/util.go
@@ -16,10 +16,6 @@ package reaper
 
 import "time"
 
-// buffer is applied when calculating whether or not the timeout
-// period is exceeded. The added buffer helps prevent false positives.
-var buffer = time.Minute * 30
-
 // helper function returns the current time.
 var now = time.Now
 


### PR DESCRIPTION
## Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

### The Basics

- [x] Commit is a single logical unit of work, only use multiple commits if doing different tasks
- [x] Commit does not include commented out code or unneeded files
- [x] rebase of main branch

### The Content

- [x] Must include testing for bug or feature
- [x] Must include appropriate documentation changes if it is introducing a new feature or changing existing functionality
- [x] Must pass existing test suites

### The Commit Message

- [x] Short meaningful description (ex: remove deprecated steps)
- [x] Uses the imperative, present tense: "change", not "changed" or "changes"
- [x] Includes motivation for the change, and contrasts its implementation with the previous behavior

### The Pull Request

# What is the reason for this change
The cleanup script adds a hardcoded buffer time of 30 minutes to its decision making. This is fine if you're working on the scale of days (the default scale is 24hours) but we've found a want to kill pending jobs a lot sooner (on the scale of 20-30 mins) to avoid large backlogs of builds and a thundering herd problem as they start running.

This PR proposes to keep the default behaviour, but make the buffer configurable so that folks can tune it to their needs :)
