### PR TITLE
Add `authtype` to logging middleware

### DIFF
--- a/logger/handler.go
+++ b/logger/handler.go
@@ -47,8 +47,7 @@ func Middleware(next http.Handler) http.Handler {
 }
 
 func authType(r *http.Request) string {
-	switch {
-	case r.Header.Get("Authorization") != "" || r.FormValue("access_token") != "":
+	if r.Header.Get("Authorization") != "" || r.FormValue("access_token") != "" {
 		return "token"
 	}
 

--- a/logger/handler.go
+++ b/logger/handler.go
@@ -36,11 +36,21 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 		end := time.Now()
 		log.WithFields(logrus.Fields{
-			"method":  r.Method,
-			"request": r.RequestURI,
-			"remote":  r.RemoteAddr,
-			"latency": end.Sub(start),
-			"time":    end.Format(time.RFC3339),
+			"method":   r.Method,
+			"request":  r.RequestURI,
+			"remote":   r.RemoteAddr,
+			"latency":  end.Sub(start),
+			"time":     end.Format(time.RFC3339),
+			"authtype": authType(r),
 		}).Debug()
 	})
+}
+
+func authType(r *http.Request) string {
+	switch {
+	case r.Header.Get("Authorization") != "" || r.FormValue("access_token") != "":
+		return "token"
+	}
+
+	return "cookie"
 }

--- a/logger/handler_test.go
+++ b/logger/handler_test.go
@@ -6,7 +6,10 @@
 
 package logger
 
-import "testing"
+import (
+	"net/http/httptest"
+	"testing"
+)
 
 func TestMiddleware(t *testing.T) {
 	t.Skip()
@@ -14,4 +17,22 @@ func TestMiddleware(t *testing.T) {
 
 func TestMiddleware_GenerateRequestID(t *testing.T) {
 	t.Skip()
+}
+
+func TestAuthType(t *testing.T) {
+	cookieRequest := httptest.NewRequest("GET", "/", nil)
+	if authType(cookieRequest) != "cookie" {
+		t.Error("authtype is not cookie")
+	}
+
+	headerRequest := httptest.NewRequest("GET", "/", nil)
+	headerRequest.Header.Add("Authorization", "test")
+	if authType(headerRequest) != "token" {
+		t.Error("authtype is not token")
+	}
+
+	formRequest := httptest.NewRequest("GET", "/?access_token=test", nil)
+	if authType(formRequest) != "token" {
+		t.Error("authtype is not token")
+	}
 }


### PR DESCRIPTION
## Description
This adds an `authtype` field to the logging middleware, which is generally useful for determining how Drone users are accessing the site, but particularly useful for determining which API tokens are actively in use.

## Testing
Added a unit test to validate function output.

## Suggestions
Please let me know if it would be preferable to make this conditional, or if there is a different place to add this logging.