### PR TITLE
Log successful API Authentication with `authtype`

### DIFF
--- a/handler/api/auth/auth.go
+++ b/handler/api/auth/auth.go
@@ -47,10 +47,21 @@ func HandleAuthentication(session core.Session) func(http.Handler) http.Handler 
 				log = log.WithField("user.admin", user.Admin)
 			}
 			log = log.WithField("user.login", user.Login)
+
+			log.WithField("authtype", authType(r)).Debugln("api: authentication successful")
+
 			ctx = logger.WithContext(ctx, log)
 			next.ServeHTTP(w, r.WithContext(
 				request.WithUser(ctx, user),
 			))
 		})
 	}
+}
+
+func authType(r *http.Request) string {
+	if r.Header.Get("Authorization") != "" || r.FormValue("access_token") != "" {
+		return "token"
+	}
+
+	return "cookie"
 }

--- a/handler/api/auth/auth_test.go
+++ b/handler/api/auth/auth_test.go
@@ -86,3 +86,21 @@ func TestAuth_Guest(t *testing.T) {
 		t.Errorf("Want status code %d, got %d", want, got)
 	}
 }
+
+func TestAuthType(t *testing.T) {
+	cookieRequest := httptest.NewRequest("GET", "/", nil)
+	if authType(cookieRequest) != "cookie" {
+		t.Error("authtype is not cookie")
+	}
+
+	headerRequest := httptest.NewRequest("GET", "/", nil)
+	headerRequest.Header.Add("Authorization", "test")
+	if authType(headerRequest) != "token" {
+		t.Error("authtype is not token")
+	}
+
+	formRequest := httptest.NewRequest("GET", "/?access_token=test", nil)
+	if authType(formRequest) != "token" {
+		t.Error("authtype is not token")
+	}
+}

--- a/logger/handler.go
+++ b/logger/handler.go
@@ -36,20 +36,11 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r.WithContext(ctx))
 		end := time.Now()
 		log.WithFields(logrus.Fields{
-			"method":   r.Method,
-			"request":  r.RequestURI,
-			"remote":   r.RemoteAddr,
-			"latency":  end.Sub(start),
-			"time":     end.Format(time.RFC3339),
-			"authtype": authType(r),
+			"method":  r.Method,
+			"request": r.RequestURI,
+			"remote":  r.RemoteAddr,
+			"latency": end.Sub(start),
+			"time":    end.Format(time.RFC3339),
 		}).Debug()
 	})
-}
-
-func authType(r *http.Request) string {
-	if r.Header.Get("Authorization") != "" || r.FormValue("access_token") != "" {
-		return "token"
-	}
-
-	return "cookie"
 }

--- a/logger/handler_test.go
+++ b/logger/handler_test.go
@@ -7,7 +7,6 @@
 package logger
 
 import (
-	"net/http/httptest"
 	"testing"
 )
 
@@ -17,22 +16,4 @@ func TestMiddleware(t *testing.T) {
 
 func TestMiddleware_GenerateRequestID(t *testing.T) {
 	t.Skip()
-}
-
-func TestAuthType(t *testing.T) {
-	cookieRequest := httptest.NewRequest("GET", "/", nil)
-	if authType(cookieRequest) != "cookie" {
-		t.Error("authtype is not cookie")
-	}
-
-	headerRequest := httptest.NewRequest("GET", "/", nil)
-	headerRequest.Header.Add("Authorization", "test")
-	if authType(headerRequest) != "token" {
-		t.Error("authtype is not token")
-	}
-
-	formRequest := httptest.NewRequest("GET", "/?access_token=test", nil)
-	if authType(formRequest) != "token" {
-		t.Error("authtype is not token")
-	}
 }


### PR DESCRIPTION
## Description
Adding a debug log line that indicates when a user successfully authenticates with the API. This provides useful context about which users are making API calls successfully.

Also moving the `authtype` log field to the `handler/api/auth` hander, since that's primarily where this information is useful.

## Testing
The change can be tested by making the following change locally and running the tests:
```diff
diff --git a/handler/api/auth/auth_test.go b/handler/api/auth/auth_test.go
index 5efb62a3..b859b8a6 100644
--- a/handler/api/auth/auth_test.go
+++ b/handler/api/auth/auth_test.go
@@ -6,9 +6,9 @@ package auth

 import (
        "database/sql"
-       "io/ioutil"
        "net/http"
        "net/http/httptest"
+       "os"
        "testing"

        "github.com/drone/drone/core"
@@ -20,7 +20,8 @@ import (
 )

 func init() {
-       logrus.SetOutput(ioutil.Discard)
+       logrus.SetLevel(logrus.DebugLevel)
+       logrus.SetOutput(os.Stdout)
 }

 func TestAuth(t *testing.T) {
```