### PR TITLE
+ sync gitea redirecturl config from gitee for customize login redire…

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -353,6 +353,7 @@ type (
 		Server       string   `envconfig:"DRONE_GITEA_SERVER"`
 		ClientID     string   `envconfig:"DRONE_GITEA_CLIENT_ID"`
 		ClientSecret string   `envconfig:"DRONE_GITEA_CLIENT_SECRET"`
+		RedirectURL  string   `envconfig:"DRONE_GITEA_REDIRECT_URL"`
 		SkipVerify   bool     `envconfig:"DRONE_GITEA_SKIP_VERIFY"`
 		Scope        []string `envconfig:"DRONE_GITEA_SCOPE" default:"repo,repo:status,user:email,read:org"`
 		Debug        bool     `envconfig:"DRONE_GITEA_DEBUG"`

--- a/cmd/drone-server/inject_login.go
+++ b/cmd/drone-server/inject_login.go
@@ -116,13 +116,17 @@ func provideGiteaLogin(config config.Config) login.Middleware {
 	if config.Gitea.Server == "" {
 		return nil
 	}
+	redirectURL := config.Gitea.RedirectURL
+	if redirectURL == "" {
+		redirectURL = config.Server.Addr + "/login"
+	}
 	return &gitea.Config{
 		ClientID:     config.Gitea.ClientID,
 		ClientSecret: config.Gitea.ClientSecret,
 		Server:       config.Gitea.Server,
 		Client:       defaultClient(config.Gitea.SkipVerify),
 		Logger:       logrus.StandardLogger(),
-		RedirectURL:  config.Server.Addr + "/login",
+		RedirectURL:  redirectURL,
 		Scope:        config.Gitea.Scope,
 	}
 }


### PR DESCRIPTION
If the domain cannot visit from 80 or 443, the redirect url needs include the port. Sync the configuration item from gitee and and DRONE_GITEA_REDIRECT_URL` according to `DRONE_GITEE_REDIRECT_URL`