### PR TITLE
Support arbitrary action value from parameter in query string

### DIFF
--- a/handler/api/repos/builds/create.go
+++ b/handler/api/repos/builds/create.go
@@ -41,6 +41,7 @@ func HandleCreate(
 			sha       = r.FormValue("commit")
 			branch    = r.FormValue("branch")
 			message   = r.FormValue("message")
+			action    = r.FormValue("action")
 			user, _   = request.UserFrom(ctx)
 		)
 
@@ -96,6 +97,9 @@ func HandleCreate(
 		}
 		if len(message) > 0 {
 			hook.Message = message
+		}
+		if len(action) > 0 {
+			hook.Action = action
 		}
 
 		for key, value := range r.URL.Query() {


### PR DESCRIPTION
Support arbitrary values for `action` in the Build Create API handler

## Current implementation

Currently, when we create a build via REST API there is no straightforward way to target a specific pipeline if more than one `custom` event is present

```yaml
---
kind: pipeline
type: docker
name: myaction1

steps:
- name: test
  image: node:9.8.0
  commands:
  - "echo MyAction1"

trigger:
  events:
    - custom
---
kind: pipeline
type: docker
name: myaction2

steps:
- name: test
  image: node:9.8.0
  commands:
  - "echo MyAction2"

trigger:
  events:
    - custom
```

In the example above both pipelines will be executed when the Build Create endpoint is called.

## New implementation

```yaml
---
kind: pipeline
type: docker
name: myaction1

steps:
- name: test
  image: node:9.8.0
  commands:
  - "echo MyAction1"

trigger:
  events:
    - custom
  # New parameter passed via Query String
  action:
    - myaction1

---

kind: pipeline
type: docker
name: myaction2

steps:
- name: test
  image: node:9.8.0
  commands:
  - "echo MyAction2"

trigger:
  events:
    - custom

  # New parameter passed via Query String
  action:
    - myaction2
```

Adding `action` in the trigger section will allow us to target only specific pipelines with a simple paramenter in the REST API:
`curl -X POST -H "Authorization: Bearer <token>" https://hostname.com/api/repos/filippopisano/drone-test-repo/builds?action=myaction1`

and

`curl -X POST -H "Authorization: Bearer <token>" https://hostname.com/api/repos/filippopisano/drone-test-repo/builds?action=myaction2`